### PR TITLE
Update CI workflows and Makefile for improved release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: Test
         run: make test
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y zip
+          sudo apt-get install -y zip tar
 
       - name: Build
         run: make full-release
@@ -43,4 +43,4 @@ jobs:
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ github.token }} 

--- a/Makefile
+++ b/Makefile
@@ -39,21 +39,24 @@ release: clean
 	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-darwin-amd64
 	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-darwin-arm64
 
-# Create release archives
 release-archives: release
 	@echo "Creating release archives..."
+	# Ensure a clean `dist` directory
+	rm -rf dist/*.tar.gz dist/*.zip
 	@if [ -n "$(TAR_CMD)" ]; then \
 		cd dist && \
 		tar -czf $(BINARY_NAME)-linux-amd64-$(VERSION).tar.gz $(BINARY_NAME)-linux-amd64 && \
 		tar -czf $(BINARY_NAME)-linux-arm64-$(VERSION).tar.gz $(BINARY_NAME)-linux-arm64 && \
 		tar -czf $(BINARY_NAME)-darwin-amd64-$(VERSION).tar.gz $(BINARY_NAME)-darwin-amd64 && \
-		tar -czf $(BINARY_NAME)-darwin-arm64-$(VERSION).tar.gz $(BINARY_NAME)-darwin-arm64; \
+		tar -czf $(BINARY_NAME)-darwin-arm64-$(VERSION).tar.gz $(BINARY_NAME)-darwin-arm64 || \
+		{ echo "Error: Failed to create tar archives"; exit 1; }; \
 	else \
 		echo "Warning: tar command not found. Skipping tar archives."; \
 	fi
 	@if [ -n "$(ZIP_CMD)" ]; then \
 		cd dist && \
-		zip $(BINARY_NAME)-windows-amd64-$(VERSION).zip $(BINARY_NAME)-windows-amd64.exe; \
+		zip $(BINARY_NAME)-windows-amd64-$(VERSION).zip $(BINARY_NAME)-windows-amd64.exe || \
+		{ echo "Error: Failed to create zip archive"; exit 1; }; \
 	else \
 		echo "Warning: zip command not found. Skipping Windows zip archive."; \
 	fi


### PR DESCRIPTION
- Upgraded Go version in CI workflows from 1.21 to 1.24.
- Enhanced Makefile to ensure a clean `dist` directory before creating release archives.
- Added error handling for tar and zip commands during archive creation.